### PR TITLE
Top-level stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.1.0
+
+* Top-level stop
+* `runDelayed` `runFn` takes all of the items instead of being called once for each item.
+* More options for `runDelayed`
+
 # 0.0.1
 
 * Initial release.

--- a/README.md
+++ b/README.md
@@ -55,3 +55,54 @@ const shutDown = async () => {
 process.on('SIGTERM', shutDown)
 process.on('SIGINT', shutDown)
 ```
+
+## scheduleDelayed
+
+Schedule data to be delivered at a later date. Duplicate payloads
+will be ignored.
+
+`scheduleFor` accepts a number of milliseconds in the future or a date.
+
+Returns a boolean indicating if the item was successfully scheduled.
+
+```typescript
+scheduleDelayed(
+  id: string,
+  data: Uint8Array,
+  scheduleFor: number | Date
+) => Promise<boolean>
+```
+
+```typescript
+// Schedule for the future
+for (let i = 1; i <= 3; i++) {
+  await scheduler.scheduleDelayed(
+    'orders',
+    `delayed data ${i}`,
+    ms(`${i * 10}s`)
+  )
+}
+```
+
+## runDelayed
+
+Check for delayed items according to the recurrence rule. Default
+interval is every minute. Calls `runFn` for the batch of items where
+the delayed timestamp is <= now.
+
+Guarantees at least one delivery.
+
+```typescript
+runDelayed(
+  id: string,
+  runFn: DelayedFn,
+  options?: DelayedOptions
+) => GracefulShutdown
+```
+
+```typescript
+// Do something with scheduled jobs
+scheduler.runDelayed('orders', async (values) => {
+  console.log('Running delayed for', values)
+})
+```

--- a/README.md
+++ b/README.md
@@ -24,9 +24,12 @@ scheduleRecurring(
 ```
 
 Schedule a recurring job. `runFn` will be called for every invocation of the rule.
+
 Set `persistScheduledMs` to a value greater than the frequency of the cron
 rule to guarantee that the last missed job will be run. This is useful for
-infrequent jobs that cannot be missed.
+infrequent jobs that cannot be missed. For example, if you have a job that runs
+at 6am daily, you might want to set `persistScheduledMs` to `ms('25h')` so that
+a missed run will be attempted up to one hour past the scheduled invocation.
 
 Guarantees at most one delivery.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ha-job-scheduler",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ha-job-scheduler",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "license": "ISC",
       "dependencies": {
         "cron-parser": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-job-scheduler",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Highly available cron job scheduler using Redis",
   "author": "GovSpend",
   "main": "dist/index.js",

--- a/src/jobScheduler.ts
+++ b/src/jobScheduler.ts
@@ -8,17 +8,26 @@ import { RedisOptions } from 'ioredis'
 
 const debug = _debug('ha-job-scheduler')
 
+/**
+ * Uses Redis to scheduling recurring jobs or delayed jobs.
+ */
 export const jobScheduler = (opts?: RedisOptions) => {
   const redis = opts ? new Redis(opts) : new Redis()
   const stopFns: StopFn[] = []
 
+  /**
+   * Attempt to get a lock for the lock key, `lockKey`, lasting `lockExpireMs`.
+   */
   const getLock = (lockKey: string, lockExpireMs = ms('1m')) =>
     redis.set(lockKey, process.pid, 'PX', lockExpireMs, 'NX')
   /**
    * Schedule a recurring job. `runFn` will be called for every invocation of the rule.
+   *
    * Set `persistScheduledMs` to a value greater than the frequency of the cron
    * rule to guarantee that the last missed job will be run. This is useful for
-   * infrequent jobs that cannot be missed.
+   * infrequent jobs that cannot be missed. For example, if you have a job that runs
+   * at 6am daily, you might want to set `persistScheduledMs` to `ms('25h')` so that
+   * a missed run will be attempted up to one hour past the scheduled invocation.
    *
    * Guarantees at most one delivery.
    */
@@ -33,6 +42,7 @@ export const jobScheduler = (opts?: RedisOptions) => {
 
     // Called for each invocation
     const runJob = async (date: Date) => {
+      deferred = defer()
       const scheduledTime = date.getTime()
       const lockKey = `${key}:${scheduledTime}:lock`
       // The process that obtained the lock
@@ -42,7 +52,6 @@ export const jobScheduler = (opts?: RedisOptions) => {
       // Lock was obtained
       if (locked) {
         debug('lock obtained - id: %s date: %s pid: %s', id, date, val)
-        deferred = defer()
         // Persist invocation
         if (shouldPersistInvocations) {
           await redis.set(persistKey, scheduledTime, 'PX', persistScheduledMs)
@@ -68,7 +77,10 @@ export const jobScheduler = (opts?: RedisOptions) => {
     }
     // Schedule recurring job
     const schedule = nodeSchedule.scheduleJob(rule, runJob)
-    // Handle shutdown gracefully
+    /**
+     * Stop the scheduler. Awaits the completion of the current invocation
+     * before resolving.
+     */
     const stop = () => {
       schedule.cancel()
       return deferred?.promise
@@ -78,44 +90,49 @@ export const jobScheduler = (opts?: RedisOptions) => {
     return { schedule, stop }
   }
 
+  const getDelayedKey = (id: string) => `delayed:${id}`
+
   /**
    * Schedule data to be delivered at a later date. Duplicate payloads
    * will be ignored.
    *
-   * `scheduleFor` accepts a number of milliseconds in the future
-   * or a date.
+   * `scheduleFor` accepts a number of milliseconds in the future or a date.
    *
    * Returns a boolean indicating if the item  was successfully scheduled.
    */
   const scheduleDelayed: Delayed = async (id, data, scheduleFor) => {
-    const key = `delayed:${id}`
+    const key = getDelayedKey(id)
     const score =
       typeof scheduleFor === 'number'
         ? new Date().getTime() + scheduleFor
         : scheduleFor.getTime()
+    // Add data to sorted set
     const res = await redis.zadd(key, score, Buffer.from(data))
     return res === 1
   }
 
   /**
    * Check for delayed items according to the recurrence rule. Default
-   * interval is every minute. Calls `runFn` for batch of items where
+   * interval is every minute. Calls `runFn` for the batch of items where
    * the delayed timestamp is <= now.
    *
    * Guarantees at least one delivery.
    */
-  const runDelayed: RunDelayed = (id, runFn, opts = {}) => {
-    const { rule = '* * * * *', lockExpireMs, limit = 100 } = opts
-    const key = `delayed:${id}`
+  const runDelayed: RunDelayed = (id, runFn, options = {}) => {
+    const { rule = '* * * * *', lockExpireMs, limit = 100 } = options
+    const key = getDelayedKey(id)
     let deferred: Deferred<void>
 
-    // Get delayed items where the delayed timestamp is <= now.
-    // Returns up to limit number of items.
+    /**
+     * Get delayed items where the delayed timestamp is <= now.
+     * Returns up to limit number of items.
+     */
     const getItems = (upper: number) =>
       redis.zrangebyscoreBuffer(key, '-inf', upper, 'LIMIT', 0, limit)
 
     // Poll Redis according to rule frequency
     const schedule = nodeSchedule.scheduleJob(rule, async (date) => {
+      deferred = defer()
       const scheduledTime = date.getTime()
       const lockKey = `${key}:${scheduledTime}:lock`
       const val = process.pid
@@ -123,7 +140,6 @@ export const jobScheduler = (opts?: RedisOptions) => {
       const locked = await getLock(lockKey, lockExpireMs)
       if (locked) {
         debug('lock obtained - id: %s date: %s pid: %s', id, date, val)
-        deferred = defer()
         const upper = new Date().getTime()
         const items = await getItems(upper)
         if (items.length) {
@@ -137,6 +153,10 @@ export const jobScheduler = (opts?: RedisOptions) => {
       }
     })
 
+    /**
+     * Stop the scheduler. Awaits the completion of the current invocation
+     * before resolving.
+     */
     const stop = () => {
       schedule.cancel()
       return deferred?.promise
@@ -147,7 +167,7 @@ export const jobScheduler = (opts?: RedisOptions) => {
   }
 
   /**
-   * Call stop on all schedulers and close Redis connection
+   * Call stop on all schedulers and close the Redis connection
    */
   const stop = async () => {
     await Promise.all(stopFns.map((stop) => stop()))

--- a/src/jobScheduler.ts
+++ b/src/jobScheduler.ts
@@ -59,7 +59,7 @@ export const jobScheduler = (opts?: RedisOptions) => {
       const date = getPreviousDate(rule)
       const expectedLastRunTime = date.getTime()
       redis.get(persistKey).then((val) => {
-        // Last run time exists, but job was run prior to expected last run
+        // Last run time exists and job was run prior to expected last run
         if (val && Number.parseInt(val, 10) < expectedLastRunTime) {
           debug('missed job - id: %s date: %s', id, date)
           runJob(date)

--- a/src/jobScheduler.ts
+++ b/src/jobScheduler.ts
@@ -109,10 +109,12 @@ export const jobScheduler = (opts?: RedisOptions) => {
     const key = `delayed:${id}`
     let deferred: Deferred<void>
 
-    // Get delayed items where the delayed timestamp is <= now
+    // Get delayed items where the delayed timestamp is <= now.
+    // Returns up to limit number of items.
     const getItems = (upper: number) =>
       redis.zrangebyscoreBuffer(key, '-inf', upper, 'LIMIT', 0, limit)
 
+    // Poll Redis according to rule frequency
     const schedule = nodeSchedule.scheduleJob(rule, async (date) => {
       const scheduledTime = date.getTime()
       const lockKey = `${key}:${scheduledTime}`

--- a/src/jobScheduler.ts
+++ b/src/jobScheduler.ts
@@ -58,8 +58,8 @@ export const jobScheduler = (opts?: RedisOptions) => {
         }
         // Run job
         await runFn(date)
-        deferred.done()
       }
+      deferred.done()
     }
 
     // Schedule last missed job if needed
@@ -149,8 +149,8 @@ export const jobScheduler = (opts?: RedisOptions) => {
           // Remove delayed items
           await redis.zremrangebyscore(key, '-inf', upper)
         }
-        deferred.done()
       }
+      deferred.done()
     })
 
     /**

--- a/src/jobScheduler.ts
+++ b/src/jobScheduler.ts
@@ -145,7 +145,7 @@ export const jobScheduler = (opts?: RedisOptions) => {
         if (items.length) {
           debug('delayed items found - id: %s num: %d', id, items.length)
           // Call run fn
-          await runFn(id, items)
+          await runFn(items)
           // Remove delayed items
           await redis.zremrangebyscore(key, '-inf', upper)
         }

--- a/src/jobScheduler.ts
+++ b/src/jobScheduler.ts
@@ -59,9 +59,8 @@ export const jobScheduler = (opts?: RedisOptions) => {
       const date = getPreviousDate(rule)
       const expectedLastRunTime = date.getTime()
       redis.get(persistKey).then((val) => {
-        const lastRunTime = val ? Number.parseInt(val, 10) : 0
         // Last run time exists, but job was run prior to expected last run
-        if (val && lastRunTime < expectedLastRunTime) {
+        if (val && Number.parseInt(val, 10) < expectedLastRunTime) {
           debug('missed job - id: %s date: %s', id, date)
           runJob(date)
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,7 @@ export type Recurring = (
 export interface DelayedOptions {
   rule?: Rule
   lockExpireMs?: number
+  limit?: number
 }
 
 export type RunDelayed = (

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,8 +30,13 @@ export type Recurring = (
   options?: RecurringOptions
 ) => GracefulShutdown
 
+export interface DelayedOptions {
+  rule?: Rule
+  lockExpireMs?: number
+}
+
 export type RunDelayed = (
   id: string,
   runFn: DelayedFn,
-  rule?: Rule
+  options?: DelayedOptions
 ) => GracefulShutdown

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,7 +11,7 @@ export interface Deferred<A> {
   promise: Promise<A>
 }
 
-export type DelayedFn = (id: string, data: Uint8Array) => Promise<void> | void
+export type DelayedFn = (id: string, data: Uint8Array[]) => Promise<void> | void
 export type StopFn = () => Promise<void>
 export type GracefulShutdown = { schedule: Job; stop: StopFn }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,7 +11,7 @@ export interface Deferred<A> {
   promise: Promise<A>
 }
 
-export type DelayedFn = (id: string, data: Uint8Array[]) => Promise<void> | void
+export type DelayedFn = (data: Uint8Array[]) => Promise<void> | void
 export type StopFn = () => Promise<void>
 export type GracefulShutdown = { schedule: Job; stop: StopFn }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,8 +12,8 @@ export interface Deferred<A> {
 }
 
 export type DelayedFn = (id: string, data: Uint8Array) => Promise<void> | void
-
-export type GracefulShutdown = { schedule: Job; stop: () => Promise<void> }
+export type StopFn = () => Promise<void>
+export type GracefulShutdown = { schedule: Job; stop: StopFn }
 
 export interface RecurringOptions {
   lockExpireMs?: number


### PR DESCRIPTION
* Top-level stop
* `runDelayed` `runFn` takes all of the items instead of being called once for each item.
* More options for `runDelayed`